### PR TITLE
Fix env path in backend tests

### DIFF
--- a/backend_test.py
+++ b/backend_test.py
@@ -7,7 +7,9 @@ from pathlib import Path
 import uuid
 
 # Load environment variables from frontend/.env
-load_dotenv(Path('/app/frontend/.env'))
+# Use a path relative to this script so it works in different environments
+env_path = Path(__file__).resolve().parent / 'frontend' / '.env'
+load_dotenv(env_path)
 
 # Get the backend URL from environment variables
 BACKEND_URL = os.environ.get('REACT_APP_BACKEND_URL')


### PR DESCRIPTION
## Summary
- use relative path to load .env file for tests

## Testing
- `python backend_test.py` *(fails: 404 page not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a21b6f7148320908102871401a808