### PR TITLE
Add env example and ignore backend .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ agenthub/agents/youtube/db
 
 # Mobile development
 android-sdk/ 
+backend/.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-# Here are your Instructions
+# Setup Instructions
+
+1. Duplicate the example environment file when configuring the backend:
+   ```bash
+   cp backend/.env.example backend/.env
+   ```
+   Then update the values as needed.
+

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,3 +1,3 @@
 MONGO_URL="mongodb://localhost:27017"
 DB_NAME="test_database"
-STRIPE_API_KEY="sk_test_emergent"
+STRIPE_API_KEY=


### PR DESCRIPTION
## Summary
- add `backend/.env.example` with sanitized values
- ignore `backend/.env`
- update setup instructions in `README`

## Testing
- `pytest -q` *(fails: REACT_APP_BACKEND_URL not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a6af028748320893d7989d94a0523